### PR TITLE
Update Program.cs

### DIFF
--- a/Test.Board/Program.cs
+++ b/Test.Board/Program.cs
@@ -14,7 +14,7 @@ namespace Test.Board
             else
             {
                 Console.WriteLine("Raspberry Pi running on {0} processor", board.Processor);
-                Console.WriteLine("Firmware rev{0}, board model {1} ({2})", board.Firmware, board.Model, board.Model.GetDisplayName() ?? "Unknown");
+                Console.WriteLine("Firmware rev{0}, board model {1} ({2})", board.Firmware, board.Model, ModelExtensionMethods.GetDisplayName(board.Model) ?? "Unknown");
                 Console.WriteLine();
                 Console.WriteLine("Serial number: {0}", board.SerialNumber);
             }


### PR DESCRIPTION
Original code does not compile, the ModelExtensionMethods.GetDisplayName(board.Model) method call format is required.
