### PR TITLE
Added support for Raspberry Pi model B.

### DIFF
--- a/Raspberry.System/Processor.cs
+++ b/Raspberry.System/Processor.cs
@@ -18,6 +18,11 @@ namespace Raspberry
         /// <summary>
         /// Processor is a BCM2709.
         /// </summary>
-        Bcm2709
+        Bcm2709,
+
+        /// <summary>
+        /// Processor is a BCM2835.
+        /// </summary>
+        Bcm2835
     }
 }


### PR DESCRIPTION
I've got quite an early Raspberry Pi model B, and when I tried to use the raspberry-sharp-io library I got errors because it didn't know about my processor type. I've simply added this, and tested with my Pi.

My Pi:
$cat /proc/cpuinfo
processor       : 0
model name      : ARMv6-compatible processor rev 7 (v6l)
BogoMIPS        : 697.95
Features        : half thumb fastmult vfp edsp java tls
CPU implementer : 0x41
CPU architecture: 7
CPU variant     : 0x0
CPU part        : 0xb76
CPU revision    : 7

Hardware        : BCM2835
Revision        : 000f
Serial          : XXX